### PR TITLE
Docs: readthedocs split maps link

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -100,6 +100,12 @@ sphinx_gallery_conf = {
 # -- Options for Linking to external docs (intersphinx) ----------------------
 intersphinx_mapping = {
     "python": ("https://docs.python.org/3", None),
+    "matplotlib": ("https://matplotlib.org/", None),
+    "pandas": ("https://pandas.pydata.org/docs/", None),
+    "geopandas": ("https://geopandas.org/en/stable/", None),
+    "pydantic": ("https://docs.pydantic.dev/latest", None),
+    "caf.toolkit": ("https://caftoolkit.readthedocs.io/en/stable/", None),
+    "folium": ("https://python-visualization.github.io/folium/latest/", None),
 }
 intersphinx_timeout = 30
 

--- a/examples/run_html_mapping_example.py
+++ b/examples/run_html_mapping_example.py
@@ -2,8 +2,9 @@
 HTML mapping example
 ====================
 
-This is a code example showing how to create an interactive map using the :mod:`caf.viz.web.mapping`
-module. This example shows two ways to create an interactive html map:
+This is a code example showing how to create an interactive map using the
+:mod:`caf.viz.web.mapping` module.
+This example shows two ways to create an interactive html map:
 
 - A single map with the desired datasets, and
 - A split map consisting of an overview map with the split geometries which link to

--- a/examples/run_html_mapping_example.py
+++ b/examples/run_html_mapping_example.py
@@ -2,10 +2,12 @@
 HTML mapping example
 ====================
 
-This is a code example showing how to create an interactive map using the web/mapping module.
-This example shows two ways to create an interactive html map:
-A single map with the desired datasets,and a split map consisting of an overview map with the
-split geometries which link to individual maps showing the datasets for each split geometry.
+This is a code example showing how to create an interactive map using the :mod:`caf.viz.web.mapping`
+module. This example shows two ways to create an interactive html map:
+
+- A single map with the desired datasets, and
+- A split map consisting of an overview map with the split geometries which link to
+  individual maps showing the datasets for each split geometry.
 
 The example uses the NUTS dataset from Eurostat and the cities dataset from Natural Earth,
 both of which are available in geodatasets.
@@ -15,6 +17,7 @@ both of which are available in geodatasets.
 # %%
 # Imports
 # -------
+import os
 import pathlib
 
 import geopandas as gpd
@@ -44,9 +47,9 @@ europe_countries = europe[europe["LEVL_CODE"] == COUNTRY_CODE]
 # %%
 # Prepare datasets for mapping
 # ----------------------------
-# Prepare datasets for mapping as a :class:`mapping.MapData` object, which includes
-# the data, the color column to use, and various mapping options in a
-# :class:`mapping.ExploreOptions` object.
+# Prepare datasets for mapping as a :class:`~caf.viz.web.mapping.MapData` object, which
+# includes the data, the color column to use, and various mapping options in a
+# :class:`~caf.viz.web.mapping.ExploreOptions` object.
 datasets = {"Countries": europe_countries, "Cities": cities}
 
 color_column = {"Countries": None, "Cities": "natscale"}
@@ -79,7 +82,7 @@ else:
 # %%
 # Create a Single Map
 # -------------------
-# :func:`~caf.viz.mapping.map_datasets` will create a :class:`folium.Map` object from the
+# :func:`~caf.viz.web.mapping.map_datasets` will create a :class:`folium.Map` object from the
 # datasets with OpenStreetMap background, it can be saved to a standalone HTML file
 # with :meth:`folium.Map.save`.
 mapping.map_datasets(datasets=mapping_datasets, mask=filter_zones, mask_name="Europe")
@@ -93,8 +96,16 @@ mapping.map_datasets(datasets=mapping_datasets, mask=filter_zones, mask_name="Eu
 # .. note::
 #     HTML file is written to generated documentation folder, so it's deployed with
 #     documentation, normally this can be saved anywhere.
-PATH_TO_SAVE_SPLIT_MAP = pathlib.Path(r"../docs/build/html/_generated/examples/split_map.html")
+
+READTHEDOCS_OUTPUT = os.getenv("READTHEDOCS_OUTPUT")
+if READTHEDOCS_OUTPUT is None:
+    PATH_TO_SAVE_SPLIT_MAP = pathlib.Path("split_map.html")
+else:
+    PATH_TO_SAVE_SPLIT_MAP = (
+        pathlib.Path(READTHEDOCS_OUTPUT) / "html/_generated/examples/split_map.html"
+    )
 PATH_TO_SAVE_SPLIT_MAP.parent.mkdir(exist_ok=True, parents=True)
+
 europe_regions = europe[europe["LEVL_CODE"] == REGION_CODE]
 
 mapping_datasets = {

--- a/examples/run_html_mapping_example.py
+++ b/examples/run_html_mapping_example.py
@@ -97,14 +97,18 @@ mapping.map_datasets(datasets=mapping_datasets, mask=filter_zones, mask_name="Eu
 #     HTML file is written to generated documentation folder, so it's deployed with
 #     documentation, normally this can be saved anywhere.
 
-READTHEDOCS_OUTPUT = os.getenv("READTHEDOCS_OUTPUT")
-if READTHEDOCS_OUTPUT is None:
-    PATH_TO_SAVE_SPLIT_MAP = pathlib.Path("split_map.html")
+readthedocs_path = os.getenv("READTHEDOCS_OUTPUT")
+subpath = "html/_generated/examples/split_map.html"
+if readthedocs_path is None:
+    split_map_path = pathlib.Path("../docs/build") / subpath
 else:
-    PATH_TO_SAVE_SPLIT_MAP = (
-        pathlib.Path(READTHEDOCS_OUTPUT) / "html/_generated/examples/split_map.html"
-    )
-PATH_TO_SAVE_SPLIT_MAP.parent.mkdir(exist_ok=True, parents=True)
+    split_map_path = pathlib.Path(readthedocs_path) / subpath
+split_map_path.parent.mkdir(exist_ok=True, parents=True)
+
+# %%
+# Use the data loaded previously to product the set of maps. An overview map with the split
+# data is saved to the ``output_path``, the lower level HTML files with the more detailed
+# data are saved in a "Split Maps" sub-folder and linked to from the overview.
 
 europe_regions = europe[europe["LEVL_CODE"] == REGION_CODE]
 
@@ -125,7 +129,7 @@ if europe_countries.crs != mapping.MAP_CRS_EPSG:
     europe_countries = europe_countries.to_crs(f"EPSG:{mapping.MAP_CRS_EPSG}")
 
 mapping.produce_map_set(
-    output_path=PATH_TO_SAVE_SPLIT_MAP,
+    output_path=split_map_path,
     datasets=mapping_datasets,
     split=europe_countries,
     split_name_column="NAME_ENGL",


### PR DESCRIPTION
# Changes

Fixed the split maps link in the HTML mapping example and added external links to dependencies.

# Tasks

- [ ] Have unittests been added (testing individual functions and their edge cases)
- [x] Has documentation (including user guide) been updated
- [x] Have new dependencies been added (or changed) in relevant `requirements.txt`
- [x] Code linting, tests and other workflows pass
