### PR TITLE
Fix: list style names

### DIFF
--- a/src/caf/viz/utils.py
+++ b/src/caf/viz/utils.py
@@ -2,18 +2,15 @@
 
 ##### IMPORTS #####
 
-# Built-Ins
 import logging
 import pathlib
 import re
-
-# Third Party
-from matplotlib.style import core
 
 ##### CONSTANTS #####
 
 LOG = logging.getLogger(__name__)
 _PACKAGE_PATH = pathlib.Path(__file__).parent
+_STYLE_SUFFIX = "mplstyle"
 
 ##### CLASSES & FUNCTIONS #####
 
@@ -38,7 +35,5 @@ def style_names() -> list[str]:
     >>> from matplotlib import pyplot as plt
     >>> plt.style.use("caf.viz.tfn")
     """
-    # MyPy false positive for missing function
-    styles = core.read_style_directory(_PACKAGE_PATH)  # type: ignore[attr-defined]
-
-    return list(styles)
+    styles = _PACKAGE_PATH.glob(f"**/*.{_STYLE_SUFFIX}")
+    return [i.stem for i in styles]


### PR DESCRIPTION
# Changes

Matplotlib's [`core.read_style_directory` function is deprecated in 3.11](https://matplotlib.org/stable/api/prev_api_changes/api_changes_3.11.0.html#matplotlib-style-core) so manually finding styles with glob.

# Tasks

- [x] Have unittests been added (testing individual functions and their edge cases) - No
- [x] Has documentation (including user guide) been updated - NA
- [x] Have new dependencies been added (or changed) in relevant `requirements.txt` - No
- [ ] Code linting, tests and other workflows pass
