### PR TITLE
Fix: mapping datasets bounds & tooltips

### DIFF
--- a/src/caf/viz/web/mapping.py
+++ b/src/caf/viz/web/mapping.py
@@ -338,7 +338,7 @@ def map_datasets(
     folium.LayerControl(collapsed=False).add_to(map_)
 
     # Fit map to bounds of mask or last dataset
-    bounds = Bounds(*mask.bounds) if mask else Bounds(*data.union_all().bounds)
+    bounds = Bounds(*mask.bounds) if mask else Bounds(*data.total_bounds)
     map_.fit_bounds([[bounds.min_y, bounds.min_x], [bounds.max_y, bounds.max_x]])
 
     if output_path is None:

--- a/src/caf/viz/web/mapping.py
+++ b/src/caf/viz/web/mapping.py
@@ -125,11 +125,29 @@ class Bounds(NamedTuple):
 
 
 @dataclasses.dataclass
+class TooltipOptions:
+    """Options for folium tooltips."""
+
+    columns: list[str]
+    aliases: dict[str, str] | None = None
+    labels: bool = True
+    localize: bool = True
+
+    @property
+    def kwargs(self) -> dict:
+        """Get keyword arguments for :class:`folium.features.GeoJsonTooltip`."""
+        kwargs = {"labels": self.labels, "localize": self.localize}
+        if self.aliases is not None:
+            kwargs["aliases"] = [self.aliases.get(i, i) for i in self.columns]
+        return kwargs
+
+
+@dataclasses.dataclass
 class ExploreOptions:
     """Options for MapData."""
 
     show_legend: bool = True
-    tooltip: bool | list[str] = False
+    tooltip: bool | list[str] | TooltipOptions = False
     popup: bool | str | list[str] = False
     style: dict = dataclasses.field(default_factory=dict)
     highlight_style: dict = dataclasses.field(default_factory=dict)
@@ -159,6 +177,16 @@ class ExploreOptions:
         if pd.api.types.is_bool_dtype(data):
             return True
         return not pd.api.types.is_numeric_dtype(data)
+
+    def get_tooltip_options(self, data: gpd.GeoDataFrame) -> TooltipOptions:
+        """Get :class:`TooltipOptions` from given tooltip."""
+        if isinstance(self.tooltip, TooltipOptions):
+            return self.tooltip
+        if isinstance(self.tooltip, list):
+            return TooltipOptions(self.tooltip)
+        if self.tooltip:
+            return TooltipOptions(data.columns.to_list())
+        return TooltipOptions([])
 
 
 @dataclasses.dataclass()
@@ -194,6 +222,7 @@ def _explore(
     else:
         legend = {}
 
+    tooltip = options.get_tooltip_options(data)
     data.explore(
         data_column,
         categorical=options.infer_categorical(
@@ -202,7 +231,8 @@ def _explore(
         cmap=options.cmap,
         legend=options.show_legend,
         m=map_,
-        tooltip=options.tooltip,
+        tooltip=tooltip.columns,
+        tooltip_kwds=tooltip.kwargs,
         popup=options.popup,
         tiles=None,
         name=name,

--- a/src/caf/viz/web/mapping.py
+++ b/src/caf/viz/web/mapping.py
@@ -136,7 +136,10 @@ class TooltipOptions:
     @property
     def kwargs(self) -> dict:
         """Get keyword arguments for :class:`folium.features.GeoJsonTooltip`."""
-        kwargs = {"labels": self.labels, "localize": self.localize}
+        kwargs: dict[str, bool | list[str]] = {
+            "labels": self.labels,
+            "localize": self.localize,
+        }
         if self.aliases is not None:
             kwargs["aliases"] = [self.aliases.get(i, i) for i in self.columns]
         return kwargs


### PR DESCRIPTION
# Changes

- Using total_bounds instead of union_all because it's simpler and union can fail on some geometries.
- Added `TooltipOptions` to provide additional formatting information for the map tooltips.

# Tasks

- [x] Have unittests been added (testing individual functions and their edge cases) - No
- [x] Has documentation (including user guide) been updated - No
- [x] Have new dependencies been added (or changed) in relevant `requirements.txt` - NA
- [x] Code linting, tests and other workflows pass
