### PR TITLE
Validate XY plot data columns

### DIFF
--- a/src/caf/viz/xy_plot.py
+++ b/src/caf/viz/xy_plot.py
@@ -255,6 +255,8 @@ def axes_plot_xy(
 
     Raises
     ------
+    KeyError
+        If any requested plot data columns aren't present in `data.data`.
     NotImplementedError
         For any plot types which haven't been implemented.
 
@@ -263,6 +265,14 @@ def axes_plot_xy(
     XYPlotType: for plot types which can be used.
     hexbin, scatter
     """
+    missing_columns = [
+        column for column in (data.x_column, data.y_column) if column not in data.data.columns
+    ]
+    if missing_columns:
+        column_label = "column" if len(missing_columns) == 1 else "columns"
+        missing = ", ".join(f"'{column}'" for column in missing_columns)
+        raise KeyError(f"plot data {column_label} not present: {missing}")
+
     if type_ == XYPlotType.HEXBIN:
         hexbin(fig, ax, data, cmap=cmap, **plot_kwargs)
 

--- a/tests/test_xy_plot.py
+++ b/tests/test_xy_plot.py
@@ -1,0 +1,94 @@
+"""Tests for general X / Y plotting functionality."""
+
+from types import SimpleNamespace
+
+import matplotlib.pyplot as plt
+import pandas as pd
+import pytest
+
+from caf.viz.xy_plot import XYPlotType, axes_plot_xy
+
+
+@pytest.fixture
+def plot_data() -> pd.DataFrame:
+    """Create simple data for XY plotting tests."""
+    return pd.DataFrame(
+        {
+            "x": [1, 2, 3],
+            "y": [4, 5, 6],
+        }
+    )
+
+
+def make_basic_data(
+    data: pd.DataFrame,
+    x_column: str,
+    y_column: str,
+) -> SimpleNamespace:
+    """Create the plotting-data attributes required by axes_plot_xy.
+
+    Avoid constructing BasicData directly so this unit test remains focused
+    on axes_plot_xy validation rather than Pydantic dataclass validation.
+    """
+    return SimpleNamespace(
+        data=data,
+        x_column=x_column,
+        y_column=y_column,
+        x_label=None,
+        y_label=None,
+        title=None,
+        auto_label=True,
+    )
+
+
+@pytest.mark.parametrize("plot_type", [XYPlotType.SCATTER, XYPlotType.HEXBIN])
+def test_axes_plot_xy_valid_columns(
+    plot_data: pd.DataFrame,
+    plot_type: XYPlotType,
+) -> None:
+    """Test plotting succeeds when both requested columns exist."""
+    fig, ax = plt.subplots()
+    try:
+        axes_plot_xy(
+            fig,
+            ax,
+            plot_type,
+            make_basic_data(plot_data, "x", "y"),
+        )
+    finally:
+        plt.close(fig)
+
+
+@pytest.mark.parametrize("plot_type", [XYPlotType.SCATTER, XYPlotType.HEXBIN])
+@pytest.mark.parametrize(
+    ("x_column", "y_column", "missing_columns"),
+    [
+        ("missing_x", "y", ("missing_x",)),
+        ("x", "missing_y", ("missing_y",)),
+        ("missing_x", "missing_y", ("missing_x", "missing_y")),
+    ],
+)
+def test_axes_plot_xy_missing_columns(
+    plot_data: pd.DataFrame,
+    plot_type: XYPlotType,
+    x_column: str,
+    y_column: str,
+    missing_columns: tuple[str, ...],
+) -> None:
+    """Test missing plotting columns raise a useful KeyError."""
+    fig, ax = plt.subplots()
+    try:
+        with pytest.raises(KeyError) as exc_info:
+            axes_plot_xy(
+                fig,
+                ax,
+                plot_type,
+                make_basic_data(plot_data, x_column, y_column),
+            )
+    finally:
+        plt.close(fig)
+
+    message = str(exc_info.value)
+    assert "plot data column" in message
+    for column in missing_columns:
+        assert column in message


### PR DESCRIPTION
## Summary

Validate the requested x and y columns in `axes_plot_xy` before dispatching to the plotting backend.

Missing columns previously produced backend-specific errors:
- scatter raised pandas `KeyError`s
- hexbin raised Matplotlib `ValueError`s

The validation now raises a consistent `KeyError` identifying the missing plot data column or columns.

## Tests

Added tests covering:
- valid x/y columns
- missing x column
- missing y column
- both columns missing
- scatter and hexbin plot types

Local validation:
- `pytest`: 20 passed
- `ruff format --check --diff`: passed
- `pylint src`: passed
- `mypy src`: passed

`ruff check --no-fix` still reports the existing `RUF036` on the `weight_column` annotation in `xy_plot.py`; the same failure was present on unmodified `main`.

Closes #8
